### PR TITLE
update to version 0.15.42

### DIFF
--- a/recipe/__init__.py
+++ b/recipe/__init__.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 from __future__ import print_function, absolute_import
 
-version_info=(0, 15, 40)
+version_info=(0, 15, 42)
 __version__ = "$VERSION"
 __name__ = "ruamel_yaml"
 __author__ = "Anthon van der Neut"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
     - ordereddict_test.patch
 
 build:
-  number: 2
+  number: 0
   no_link: .*\.(pyd|dll)  # [win]
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.15.40" %}
+{% set version = "0.15.42" %}
 # The version_info tuple in __init__.py must also be updated
 
 package:
@@ -8,7 +8,7 @@ package:
 source:
   fn: ruamel_yaml-{{ version }}.tar.gz
   url: https://bitbucket.org/ruamel/yaml/get/{{ version }}.tar.gz
-  sha256: 7349193b7f6b3f88f84fc91a98989542e75c1d6d015eebd9f9ae8343c331bb04
+  sha256: 12a773b97010c419f490a37ecd9f1a5b42096dff21c3c2962390f3c45fa7cdaf
   patches:
     - ordereddict_test.patch
 


### PR DESCRIPTION
Versions `0.15.39` through `0.15.41` suffer from a bug (https://bitbucket.org/ruamel/yaml/issues/204/, introduced by https://bitbucket.org/ruamel/yaml/pull-requests/27/) where decoding Unicode strings would fail on Python 2 interpreters compiled with `--enable-unicode=ucs2` (e.g., the ones from `python[channel=defaults, subdir=win-64, version="2.7.*"]`). 