### PR TITLE
update to version 0.15.46

### DIFF
--- a/recipe/__init__.py
+++ b/recipe/__init__.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 from __future__ import print_function, absolute_import
 
-version_info=(0, 15, 44)
+version_info=(0, 15, 45)
 __version__ = "$VERSION"
 __name__ = "ruamel_yaml"
 __author__ = "Anthon van der Neut"

--- a/recipe/__init__.py
+++ b/recipe/__init__.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 from __future__ import print_function, absolute_import
 
-version_info=(0, 15, 45)
+version_info=(0, 15, 46)
 __version__ = "$VERSION"
 __name__ = "ruamel_yaml"
 __author__ = "Anthon van der Neut"

--- a/recipe/__init__.py
+++ b/recipe/__init__.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 from __future__ import print_function, absolute_import
 
-version_info=(0, 15, 43)
+version_info=(0, 15, 44)
 __version__ = "$VERSION"
 __name__ = "ruamel_yaml"
 __author__ = "Anthon van der Neut"

--- a/recipe/__init__.py
+++ b/recipe/__init__.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 from __future__ import print_function, absolute_import
 
-version_info=(0, 15, 42)
+version_info=(0, 15, 43)
 __version__ = "$VERSION"
 __name__ = "ruamel_yaml"
 __author__ = "Anthon van der Neut"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.15.44" %}
+{% set version = "0.15.45" %}
 # The version_info tuple in __init__.py must also be updated
 
 package:
@@ -8,7 +8,7 @@ package:
 source:
   fn: ruamel_yaml-{{ version }}.tar.gz
   url: https://bitbucket.org/ruamel/yaml/get/{{ version }}.tar.gz
-  sha256: 51d9435dfccf55e679456181869019221daf409b1e74640d5dfa97d5976f823b
+  sha256: eade9d13c5b67efb82abf54e61de2f5c934d8c7b8084ce3392a78488dc1f09c2
   patches:
     - ordereddict_test.patch
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.15.45" %}
+{% set version = "0.15.46" %}
 # The version_info tuple in __init__.py must also be updated
 
 package:
@@ -8,7 +8,7 @@ package:
 source:
   fn: ruamel_yaml-{{ version }}.tar.gz
   url: https://bitbucket.org/ruamel/yaml/get/{{ version }}.tar.gz
-  sha256: eade9d13c5b67efb82abf54e61de2f5c934d8c7b8084ce3392a78488dc1f09c2
+  sha256: 256fe31c23003339f7a056a68ffdd7a55544ae1195a9a1f155effe51e46d175f
   patches:
     - ordereddict_test.patch
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.15.42" %}
+{% set version = "0.15.43" %}
 # The version_info tuple in __init__.py must also be updated
 
 package:
@@ -8,7 +8,7 @@ package:
 source:
   fn: ruamel_yaml-{{ version }}.tar.gz
   url: https://bitbucket.org/ruamel/yaml/get/{{ version }}.tar.gz
-  sha256: 12a773b97010c419f490a37ecd9f1a5b42096dff21c3c2962390f3c45fa7cdaf
+  sha256: bb185ebfe556ebd3185f8a4a30615636292984e54cec53dccd6803172f7aa55b
   patches:
     - ordereddict_test.patch
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.15.43" %}
+{% set version = "0.15.44" %}
 # The version_info tuple in __init__.py must also be updated
 
 package:
@@ -8,7 +8,7 @@ package:
 source:
   fn: ruamel_yaml-{{ version }}.tar.gz
   url: https://bitbucket.org/ruamel/yaml/get/{{ version }}.tar.gz
-  sha256: bb185ebfe556ebd3185f8a4a30615636292984e54cec53dccd6803172f7aa55b
+  sha256: 51d9435dfccf55e679456181869019221daf409b1e74640d5dfa97d5976f823b
   patches:
     - ordereddict_test.patch
 

--- a/recipe/ordereddict_test.patch
+++ b/recipe/ordereddict_test.patch
@@ -1,36 +1,13 @@
 --- a/_test/test_yamlfile.py
 +++ b/_test/test_yamlfile.py
-@@ -54,21 +54,21 @@
-         - b: 2
-         """)
-
--    @pytest.mark.skipif(sys.version_info >= (3, 0) or
--                        platform.python_implementation() != "CPython",
--                        reason="ruamel.yaml not available")
--    def test_dump_ruamel_ordereddict(self):
+@@ -58,9 +58,9 @@
+     @pytest.mark.skipif(sys.version_info >= (3, 0) or
+                         platform.python_implementation() != "CPython",
+                         reason="ruamel.yaml not available")
+     def test_dump_ruamel_ordereddict(self):
 -        from ruamel.ordereddict import ordereddict
--        # OrderedDict mapped to !!omap
--        x = ordereddict([('a', 1), ('b', 2)])
--        res = ruamel.yaml.dump(x,
--                               Dumper=ruamel.yaml.RoundTripDumper,
--                               default_flow_style=False)
--        assert res == dedent("""
--        !!omap
--        - a: 1
--        - b: 2
--        """)
-+    # @pytest.mark.skipif(sys.version_info >= (3, 0) or
-+    #                     platform.python_implementation() != "CPython",
-+    #                     reason="ruamel.yaml not available")
-+    # def test_dump_ruamel_ordereddict(self):
-+    #     from ruamel.ordereddict import ordereddict
-+    #     # OrderedDict mapped to !!omap
-+    #     x = ordereddict([('a', 1), ('b', 2)])
-+    #     res = ruamel.yaml.dump(x,
-+    #                            Dumper=ruamel.yaml.RoundTripDumper,
-+    #                            default_flow_style=False)
-+    #     assert res == dedent("""
-+    #     !!omap
-+    #     - a: 1
-+    #     - b: 2
-+    #     """)
++        ordereddict = pytest.importorskip('ruamel.ordereddict').ordereddict
+         import ruamel.yaml  # NOQA
+         # OrderedDict mapped to !!omap
+         x = ordereddict([('a', 1), ('b', 2)])
+         res = ruamel.yaml.dump(x,


### PR DESCRIPTION
Another followup to gh-2:
> Versions `0.15.39` through ~`0.15.41`~ `0.15.42` suffer from a bug (https://bitbucket.org/ruamel/yaml/issues/204/, introduced by https://bitbucket.org/ruamel/yaml/pull-requests/27/) where decoding Unicode strings would fail on Python 2 interpreters compiled with `--enable-unicode=ucs2` (e.g., the ones from `python[channel=defaults, subdir=win-64, version="2.7.*"]`).

Version `0.15.43` *truly* fixes it completely (promise :wink:), also on Windows which `0.15.42` didn't cover.